### PR TITLE
Add markdown copies of slides

### DIFF
--- a/slides/day1_intro.md
+++ b/slides/day1_intro.md
@@ -1,0 +1,122 @@
+
+# Section 1: 1.1 – Welcome & Workshop Overview
+
+## Slide: Title
+
+- "Day 1: Intro to MD & LAMMPS for Metallurgy"
+- Workshop Instructor, affiliation, date
+
+
+## Slide: Objectives & Agenda
+
+- Goals: grasp MD fundamentals, explore LAMMPS structure, run first demo
+- Agenda:
+  - short theory primer
+  - demo overview
+  - live LJ run
+  - Ovito intro
+  - Q&A
+
+# Section 2: 1.2 – Molecular Dynamics Fundamentals
+
+## Slide: What is MD?
+
+- Definition: classical simulation of atoms using Newtonian mechanics
+- Relevance to metallurgy and metals
+
+
+
+## Slide: Equations of Motion
+
+$$
+\frac{d\mathbf{r}_i}{dt} = \mathbf{v}_i,\quad m_i\frac{d\mathbf{v}_i}{dt} = \mathbf{F}_i = -\nabla_i V(\{\mathbf{r}_j\})
+$$
+
+## Slide: Interatomic Potentials
+
+- Lennard-Jones vs. EAM usage in metals
+- Emphasize EAM for metallic bonding
+
+
+
+# Section 3: 1.3 – LAMMPS Basics
+
+## Slide: What is LAMMPS?
+
+- Parallel MD code for materials simulation :contentReference[oaicite:1]{index=1}
+
+## Slide: LAMMPS Workflow
+
+- prepare input → run → analyze → visualize
+
+
+
+## Slide: Anatomy of Input Script
+
+```bash
+# in.lj – Lennard-Jones demo
+units lj
+atom_style atomic
+lattice fcc 0.8442
+region box block 0 10 0 10 0 10
+create_box 1 box
+create_atoms 1 box
+pair_style lj/cut 2.5
+pair_coeff 1 1 1.0 1.0 2.5
+fix 1 all nve
+run 10000
+```
+
+# Section 4: 1.4 – Live Demo: LJ Melt in LAMMPS
+
+## Slide: Setup & Goals
+
+- LJ melt demo: simulate FCC melt, compute thermodynamic properties
+
+## Slide: Input Script Overview
+
+```yaml
+include-code-files:
+  - ../scripts/in.lj
+```
+
+## Slide: Run Commands
+
+```bash
+lmp -in in.lj
+```
+
+## Slide: Expected Output
+
+- Thermo log sample
+
+
+
+
+# Section 5: 1.5 – Visualization with Ovito
+
+## Slide: Why Ovito?
+
+- Supports LAMMPS dumps :contentReference[oaicite:2]{index=2}
+
+## Slide: Loading Trajectories
+
+will put ovito images later
+
+## Slide: Basic Analysis in Ovito
+
+- Displacement plots
+- Coloring atoms by type or energy
+
+# Section 6: 1.6 – Q&A & Day 2 Preview
+
+## Slide: Recap
+
+- MD basics, LJ demo, Ovito intro
+
+## Slide: Day 2 Teaser
+
+- crystal defects
+- dislocations
+- diffusion
+

--- a/slides/intro.md
+++ b/slides/intro.md
@@ -1,0 +1,45 @@
+
+
+---
+
+## Slide 1 — Why *Classical* Molecular Dynamics?
+
+::: incremental
+- **Classical Molecular Dynamics (MD)** simulates how atoms or molecules move by **numerically integrating Newton’s equations of motion for every particle** in the system — positions and velocities are updated at each time–step using a chosen force-field \(U(\{\mathbf r\})\). :contentReference[oaicite:0]{index=0}  
+- The method treats particles **classically** (no explicit quantum effects) but captures temperature, pressure & collective phenomena in systems spanning *\(10^2\!-\!10^8\) atoms* and *ps → µs* time windows. :contentReference[oaicite:1]{index=1}  
+- **Historic origin:** *Alder & Wainwright (1957)* used hard-sphere MD to show fluid–solid phase transitions — the first computer “microscope”. :contentReference[oaicite:2]{index=2}  
+- **Today:** MD is the bridge between quantum DFT (Å & fs) and continuum FEM (mm & s), enabling predictive metallurgy, diffusion, dislocation kinetics, and nanomechanics. :contentReference[oaicite:3]{index=3}  
+:::
+
+![Historic (1957) vs. modern GPU MD](../images/md_history_vs_today.png){#fig:history width="80%"}
+
+> **Key equation:**  
+> \[
+> m_i\frac{d^{2}\mathbf r_i}{dt^{2}} = -\nabla_{\!i}\,U(\{\mathbf r\}) ,
+> \quad U = \text{EAM/MEAM/… force-field}
+> \]  
+> *\(m_i\)* = atom mass, *\(\mathbf r_i\)* = position, *\(U\)* = potential energy. :contentReference[oaicite:4]{index=4}
+
+
+---
+
+## Slide 2 — What is LAMMPS?
+
+- **Large-scale Atomic/Molecular Massively Parallel Simulator**  
+- Written in modern C++; hundreds of interatomic potentials supported  
+- Scales from laptop to supercomputer via MPI/OpenMP/GPU  
+- ![LAMMPS logo](../images/lammps_logo_placeholder.png){#fig:lammps_logo width="60%"}
+
+---
+
+
+
+## Slide 3 — MD integration loop
+
+- Below is a schematic of the MD time-integration loop:
+
+![MD integration loop](../images/md_integration_loop_placeholder.png){#fig:mdloop width="80%"}
+
+> $\Delta t \ll \frac{2\pi}{\omega_{\max}}$
+
+---


### PR DESCRIPTION
## Summary
- generate `.md` mirrors for every Quarto slide file
- include raw LAMMPS scripts at end of day-2 slides

## Testing
- `find slides -name '*.qmd' | wc -l`
- `find slides -name '*.md' | wc -l`


------
https://chatgpt.com/codex/tasks/task_e_6864ec048a28832488ef24feca726d61