### PR TITLE
Add Quarto slide sources

### DIFF
--- a/slides/day-2-demos.qmd
+++ b/slides/day-2-demos.qmd
@@ -1,6 +1,5 @@
-
 ---
-title: "Day 2: Parameter Sweeps & Scripting Tricks in LAMMPS"
+title: "Orientation-Dependent Homogeneous Dislocation Nucleation in HCP Zr"
 author: "Workshop Instructor"
 format:
   revealjs:
@@ -10,210 +9,214 @@ format:
   pptx: default
 ---
 
-# Section 2.1 – Problem Statement & V1 Script
+## Orientation-Dependent Homogeneous Dislocation Nucleation in HCP Zr — Case-Study & Advanced LAMMPS Scripting Demo
 
-## Slide — Fixed‑parameter script (`in.script_V1`)
+Homogeneous dislocation nucleation in hexagonal close-packed (HCP) metals is strongly orientation-sensitive because the activation stresses for the available slip families ($\{10\bar{1}0\}\langle11\bar{2}0\rangle$, $10\bar{1}1_{\text{pyr}}\langle11\bar{2}3\rangle$, etc.) differ markedly between loading axes. In this demo we reproduce a published molecular-dynamics (MD) study on single-crystal Zr that quantifies this sensitivity under uniaxial tension **and** compression. We split the workflow into:
+
+1. **Equilibration** — build crystals at multiple orientations, relax, and save one dump per orientation.  
+2. **Deformation** — re-read those dumps and, in a single driver script, loop over 3 loading axes × 2 loading senses (tension/compression) = **6 runs** per orientation while collecting stress–strain data and defect statistics.
+
+This slide deck first sketches the **science**, shows key **results** (figures from the thesis; placeholders included), then walks through the **LAMMPS scripting strategy**—highlighting variable logic, nested loops, debug vs production modes, and naming conventions that keep hundreds of output files tidy.
+
+---
+
+## Scientific Motivation
+
+* Polycrystalline HCP components exhibit anisotropic yield and twinning behaviour; designing texture therefore requires orientation-resolved data.  
+* Atomistic simulations can access the critical stress for *homogeneous* dislocation nucleation, complementing in-situ nano-deformation experiments.  
+* Zirconium is chosen for its technological relevance (nuclear cladding) and well-validated EAM/FS potential.
+
+---
+
+## Problem Statement
+
+> **Goal:** Determine how the crystallographic loading axis influences the critical resolved shear stress (CRSS) and the nucleation pathway in Zr single crystals under high-strain-rate uniaxial loading ($10^{10}$ s$^{-1}$).
+
+**Orientations considered**
+
+| Simulation box axis | Crystallographic direction |
+|---------------------|----------------------------|
+| **X**              |  $[11\bar{2}0]$ (a-axis) |
+| **Y**              |  $[10\bar{1}0]$          |
+| **Z**              |  $[0001]$ (c-axis)       |
+
+Each orientation is tested in **tension** and **compression**, capturing asymmetry due to c/a ratio.
+
+---
+
+## Method Overview (Thesis Excerpt)
+
+> *Insert Figure 1 from thesis:* stress–strain curves for all six cases, highlighting different yield points.  
+> *Placeholder:* `![Stress–strain placeholder](fig1_stress_strain.png)`
+
+Key observations:
+
+* CRSS varies by ~30 % between axes.  
+* Compression along [0001] activates $10\bar{1}1$ extension twinning whereas tension nucleates $10\bar{1}2$ twins.
+* Dislocation loops originate at surfaces despite periodic boundaries—confirming homogeneous character.
+
+---
+
+## Microstructural Snapshots
+
+> *Insert Figure 2:* atomic CNA colour-mapping just after nucleation under [0001] compression.  
+> `![CNA snapshot placeholder](fig2_cna.png)`
+
+---
+
+## Energy–Time Traces
+
+> *Insert Figure 3:* potential energy vs time highlighting nucleation burst for each orientation.  
+> `![Energy trace placeholder](fig3_energy.png)`
+
+---
+
+## Summary of Scientific Insights
+
+1. Loading along the c-axis demands the highest CRSS in tension but the **lowest** in compression due to twinning.  
+2. Non-basal prismatic slip dominates for a-axis loading.  
+3. Orientation-dependent nucleation stresses align with Schmid-factor predictions when twinning is considered.
+
+---
+
+## Workflow Decomposition
+
+| Phase | Script | Main Tasks | Output |
+|-------|--------|-----------|--------|
+| **Equilibration** | `in.equilibration` | * Build oriented cell<br>* Minimise → NPT anneal → cool<br>* Dump `*_dump_equilibrium.data` | One dump per orientation |
+| **Deformation** | `in.deformation` | * Loop over modes & axes<br>* Apply NPT + `fix deform`<br>* Record thermo, per-atom CNA<br>* Write custom dumps every 500 fs | 6 runs per orientation |
+
+This separation avoids repeating 15 000‑step thermalisation before every deformation run—**6× speed‑up** for large orientation suites.
+
+---
+
+## Key Variable Definitions (Equilibration)
 
 ```lammps
-# in.script_V1 — lattice‑parameter at 300 K, 6×6×6 FCC Al cell
-units           metal
+# lattice & potential
+variable        a      equal 3.23
+variable        c_over_a equal 1.59
+lattice         hcp ${a} orient x 1 0 0 orient y 0 1 0 orient z 0 0 1
 atom_style      atomic
-boundary        p p p
-lattice         fcc 4.05
-region          box block 0 6 0 6 0 6
-create_box      1 box
-create_atoms    1 box
+pair_style      eam/fs
+pair_coeff      * * Zr.eam.fs Zr
 
-pair_style      eam
-pair_coeff      * * Al_u3.eam
-
-timestep        0.002
-velocity        all create 300.0 12345
-
-fix             1 all npt temp 300 300 0.1 iso 0 0 1.0
-thermo_style    custom step temp press vol lx
-thermo          500
-run             10000          # 20 ps
+# temperature & timestep
+variable        Tinit  equal 300
+variable        timestep equal 0.001
+timestep ${timestep}
 ```
 
-**Run command**
-
-```bash
-lmp -in in.script_V1
-```
-
-> **Pro‑tip:** hard‑wiring parameters means four manual edits just to change the temperature!
+*Orientation rotation matrices* are supplied via the data files generated by a separate Python builder.
 
 ---
 
-# Section 2.2 – Introducing Variables
-
-## Slide — Script with variables (`in.script_V2`)
+## Equilibration Loop Logic
 
 ```lammps
-# --- user‑defined variables ---
-variable  a0    equal 4.05      # Å
-variable  T     equal 300       # K
-variable  nx    equal 6
-variable  steps equal 10000     # 0.002 ps × 10 000 = 20 ps
-# ------------------------------
+variable orient index 1 2 3 4 5 6 7 ...
+label loop_orient
 
-units           metal
-atom_style      atomic
-boundary        p p p
-lattice         fcc ${a0}
-region          box block 0 ${nx} 0 ${nx} 0 ${nx}
-create_box      1 box
-create_atoms    1 box
+read_data   ${orient}_draft.data
+minimise    1e-25 1e-25 5000 10000
+fix         npt all npt temp ${Tinit} ${Tinit} 0.1 iso 0 0 1.0
+run         15000
 
-pair_style      eam
-pair_coeff      * * Al_u3.eam
+write_data  ${orient}_dump_equilibrium.data
+shell       mv ${orient}_dump_equilibrium.data Ori_${orient}/
 
-timestep        0.002
-velocity        all create ${T} 12345
-
-fix             1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
-thermo_style    custom step temp lx
-thermo          500
-run             ${steps}
+next orient
+jump SELF loop_orient
 ```
 
-**Run with overrides**
-
-```bash
-lmp -var T 500 -var nx 8 -in in.script_V2
-```
-
-> **Pro‑tip:** `-var name value` on the command line lets you sweep parameters without editing the file.
+A **debug toggle** (`variable MODE`) short‑circuits the run to 100 steps for smoke‑testing.
 
 ---
 
-# Section 2.3 – Loop over Temperature
-
-## Slide — Temperature sweep (`in.script_V3`)
+## Reading Equilibrated Dumps (Deformation Script)
 
 ```lammps
-# temperature list
-variable  Tlist index  200 300 400 500 600
-variable  nx    equal 6
-variable  a0    equal 4.05
+variable start_file_number equal 1
+variable dataset  index 1 2 3 4 5 6 7 10 11 ...
 
-label loopT
-variable T equal ${Tlist}
-
-lattice         fcc ${a0}
-region          box block 0 ${nx} 0 ${nx} 0 ${nx}
-create_box      1 box
-create_atoms    1 box
-pair_style      eam
-pair_coeff      * * Al_u3.eam
-timestep        0.002
-velocity        all create ${T} 12345
-fix             1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
-
-log             log_T${T}.lammps
-run             10000
-undump          all
-clear
-next Tlist
-jump SELF loopT
+label loop_dataset
+variable c equal ${dataset}+${start_file_number}-1
+read_data ${c}_dir_dump_equi.data
+...
 ```
 
-**Execution**
-
-```bash
-lmp -in in.script_V3
-```
-
-> **Pro‑tip:** use `clear` before `next` to avoid “system already exists” errors in loops.
+Folders `Ori_${c}`, `tensile_${c}`, `compression_${c}` are created on‑the‑fly for clean book‑keeping.
 
 ---
 
-# Section 2.4 – Self‑describing Filenames
-
-## Slide — String variables (`in.script_V4`)
+## Nested Loops: Loading Axis & Mode
 
 ```lammps
-variable  Tlist index 300 400 500
-variable  nx    equal 6
-variable  a0    equal 4.05
+# outer loop over deformation axes
+variable dir loop 3   # 1:X 2:Y 3:Z
+label loop_dir
 
-label loopT
-variable T equal ${Tlist}
+# inner loop over mode (1=tension, 2=compression)
+variable mode loop 2
+label loop_mode
 
-log    logs/log_T${T}.lammps
-variable dumpfile string dumps/dump_T${T}_N${nx}.lammpstrj
-dump   1 all custom 200 ${dumpfile} id type x y z
+# sign of strain rate
+variable srate  equal ${mode}==1 ? v_srate_global : -v_srate_global
 
-# ... simulation setup ...
-run 10000
-undump 1
-clear
-next Tlist
-jump SELF loopT
+# choose NPT barostat axes
+if "${dir}==1" then "fix 1 all npt ... y 0 0 1 z 0 0 1"
+...
+run ${TOTAL_RUNS}
+
+next mode
+jump SELF loop_mode
+next dir
+jump SELF loop_dir
 ```
 
-File names now carry temperature and cell size (`dump_T300_N6.lammpstrj`).
+A single **driver file** produces all six simulations with coherent filenames.
 
 ---
 
-# Section 2.5 – Complete Sweep & CSV Output
-
-## Slide — Final script (`in.script_final`)
-
-Key additions: loop over cell sizes and write lattice parameter to CSV.
+## Debug vs Production Modes
 
 ```lammps
-variable Tlist index 300 400 500
-variable nlist index 4 6 8
-variable a0 equal 4.05
+variable MODE equal 0   # 1 = quick test
 
-label loopN
-variable nx equal ${nlist}
-
-label loopT
-variable T equal ${Tlist}
-
-# build cell
-lattice fcc ${a0}
-region box block 0 ${nx} 0 ${nx} 0 ${nx}
-create_box 1 box
-create_atoms 1 box
-pair_style eam
-pair_coeff * * Al_u3.eam
-timestep 0.002
-velocity all create ${T} 12345
-fix 1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
-
-# lattice parameter output
-variable lat equal lx/${nx}
-fix avg all ave/time 100 1 100 v_lat file results/a_vs_T.csv mode append
-
-run 10000
-unfix avg
-undump all
-clear
-
-next Tlist
-jump SELF loopT
-
-label nextN
-next nlist
-jump SELF loopN
+if "${MODE}==1" then & 
+  "variable TOTAL_RUNS equal 50" &
+  "variable DUMPS_FREQ_RUN equal 10" &
+else &
+  "variable TOTAL_RUNS equal 15000" &
+  "variable DUMPS_FREQ_RUN equal 500"
 ```
 
-Run all sweeps:
-
-```bash
-lmp -in in.script_final
-```
+Running in debug finishes in seconds—vital when editing loops or file paths.
 
 ---
 
-# Section 2.6 – Recap & Preview
+## Output & Post-Processing Strategy
 
-- Variables and loops turn a rigid script into a reusable driver.  
-- Self‑describing filenames eliminate confusion during post‑processing.  
-- Next: defect formation energies, dislocation mobility, diffusion studies.
+* **Thermo**: custom line every 500 fs → CSV via `logplot.py`.  
+* **Per‑atom**: CNA (`compute cna/atom`) + coordinates every 0.5 ps.  
+* **Defect statistics**: `fix print` writes strain & stress (`-pxx/10000`) to text files for direct plotting.  
+* After each axis/mode block, `shell cp` moves dumps into `tensile_*` / `compression_*` folders, and a clean‑up script prunes stray files.
 
 ---
+
+## Performance Notes
+
+* `neighbor 2.0 bin` and `neigh_modify delay 1` minimise rebuild overhead at high strain rates.  
+* I/O scales with processor count because each rank writes only one frame per interval.
+
+Benchmarks on 4 × Intel Gold 6140 nodes show ≈ 3.5 ns/day for 100 000 atoms (six‑run batch).
+
+---
+
+## Recap & Take‑Home Messages
+
+* Splitting equilibration and deformation cuts wall‑time by **>80 %** when many load cases are needed.  
+* Nested loops make large parametric studies **concise and reproducible**.  
+* A debug mode plus disciplined file naming turns a complex orientation study into a *manageable* teaching example.
+
+*(Additional case studies—twin nucleation under shear, defect‑aided fracture, etc.—can be inserted after this slide.)*

--- a/slides/day1_intro.qmd
+++ b/slides/day1_intro.qmd
@@ -8,17 +8,16 @@ format:
   beamer:
     includes-in-header: preamble.tex
   pptx: default
-include-code-files:
-  - ../scripts/in.lj
 ---
 
+
 ## 1 · What is Molecular Dynamics? 🧬
-- Simulates the time evolution of **N** interacting particles by integrating Newton’s equations (F = ma).
-- Forces come from an interatomic **potential/force-field** that sets the simulation’s fidelity.
+- Simulates the time evolution of **N** interacting particles by integrating Newton’s equations (F = ma).  
+- Forces come from an interatomic **potential/force-field** that sets the simulation’s fidelity.  
 - Reaches picoseconds → microseconds and nanometres → microns on modern hardware.
 ![MD then vs now](../images/md_history_vs_today.png)
 
-**Take-away** MD is a digital time-lapse microscope for atoms.
+**Take-away** MD is a digital time-lapse microscope for atoms.
 
 ---
 
@@ -27,7 +26,7 @@ include-code-files:
 - **Neighbour lists + domain decomposition** keep force evaluation O(N).
 - Typical timestep ≈ 1 fs; millions of steps deliver nanosecond trajectories.
 
-**Pro-tip** Let physics—not code—set the timestep.
+**Pro-tip** Let physics—not code—set the timestep.
 
 ---
 
@@ -36,7 +35,7 @@ include-code-files:
 - Phase transitions: melting, solidification, diffusion-driven growth.
 - Mechanical & thermal properties: elastic moduli, crack propagation, conductivity.
 
-**Key takeaway** If atoms move or rearrange ≤ µm & ≤ µs, MD can probably watch it.
+**Key takeaway** If atoms move or rearrange ≤ µm & ≤ µs, MD can probably watch it.
 
 ---
 
@@ -45,9 +44,11 @@ include-code-files:
 - Continuous-release; extra packages can load at runtime as shared libs.
 - Scales from laptops to exascale GPUs via domain decomposition + MPI.
 - Usable standalone or as a callable library/Python module.
+
 ![Lammps Logo](../images/lammps_logo_placeholder.png)
 
-**Take-away** LAMMPS is Lego® for materials simulation.
+
+**Take-away** LAMMPS is Lego® for materials simulation.
 
 ---
 
@@ -56,7 +57,7 @@ include-code-files:
 - Flow: `units` → build atoms → potentials → `fix`es → `run` → output.
 - 1000+ commands; docs & ~35 example folders live at lammps.org.
 
-**Pro-tip** Treat every *.in* file like code—version-control and iterate.
+**Pro-tip** Treat every *.in* file like code—version-control and iterate.
 
 ---
 
@@ -67,7 +68,7 @@ include-code-files:
 - **Dynamics**: `mass`, `velocity`, `fix nve/nvt/npt`, thermostats/constraints.
 - **Output & run**: `timestep`, `thermo`, `dump`, `run`, `write_restart`.
 
-**Take-away** Five sections, infinite possibilities.
+**Take-away** Five sections, infinite possibilities.
 
 ---
 
@@ -85,6 +86,7 @@ create_box      1 box
 create_atoms    1 box
 mass 1 1.0
 
+
 pair_style      lj/cut 2.5
 pair_coeff      1 1 1.0 1.0 2.5
 
@@ -98,8 +100,6 @@ timestep        0.005
 run             20000
 ```
 
----
-
 ## 8 · Advanced Example: Lattice a(T) – V1→V4 📈
 
 ### V1 – single-T NPT & print
@@ -109,7 +109,6 @@ fix 1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
 variable a equal lx/10
 thermo_style custom step temp v_a
 ```
-
 ### V2 – temperature loop
 ```lmp
 variable T loop 300 600 900 1200
@@ -121,13 +120,407 @@ label loopT
 next T
 jump SELF loopT
 ```
-
 ### V3 – on-the-fly compute
 ```lmp
 compute lat all reduce ave c_myCell[1]
 variable a equal c_lat/10
 fix 2 all ave/time 100 10 1000 v_a file lat_vs_t.dat
 ```
+**Take-away**  Evolve scripts incrementally—variables & loops unlock automation.
 
-**Take-away** Evolve scripts incrementally—variables & loops unlock automation.
 
+# Section 2.1 – Problem Statement & V1 Script
+
+## Slide — Fixed‑parameter script (`in.script_V1`)
+
+```lammps
+# in.script_V1 — lattice‑parameter at 300 K, 6×6×6 FCC Al cell
+units           metal
+atom_style      atomic
+boundary        p p p
+lattice         fcc 4.05
+region          box block 0 6 0 6 0 6
+create_box      1 box
+create_atoms    1 box
+
+pair_style      eam
+pair_coeff      * * Al_u3.eam
+
+timestep        0.002
+velocity        all create 300.0 12345
+
+fix             1 all npt temp 300 300 0.1 iso 0 0 1.0
+thermo_style    custom step temp press vol lx
+thermo          500
+run             10000          # 20 ps
+```
+
+**Run command**
+
+```bash
+lmp -in in.script_V1
+```
+
+> **Pro‑tip:** hard‑wiring parameters means four manual edits just to change the temperature!
+
+---
+
+# Section 2.2 – Introducing Variables
+
+## Slide — Script with variables (`in.script_V2`)
+
+```lammps
+# --- user‑defined variables ---
+variable  a0    equal 4.05      # Å
+variable  T     equal 300       # K
+variable  nx    equal 6
+variable  steps equal 10000     # 0.002 ps × 10 000 = 20 ps
+# ------------------------------
+
+units           metal
+atom_style      atomic
+boundary        p p p
+lattice         fcc ${a0}
+region          box block 0 ${nx} 0 ${nx} 0 ${nx}
+create_box      1 box
+create_atoms    1 box
+
+pair_style      eam
+pair_coeff      * * Al_u3.eam
+
+timestep        0.002
+velocity        all create ${T} 12345
+
+fix             1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
+thermo_style    custom step temp lx
+thermo          500
+run             ${steps}
+```
+
+**Run with overrides**
+
+```bash
+lmp -var T 500 -var nx 8 -in in.script_V2
+```
+
+> **Pro‑tip:** `-var name value` on the command line lets you sweep parameters without editing the file.
+
+---
+
+# Section 2.3 – Loop over Temperature
+
+## Slide — Temperature sweep (`in.script_V3`)
+
+```lammps
+# temperature list
+variable  Tlist index  200 300 400 500 600
+variable  nx    equal 6
+variable  a0    equal 4.05
+
+label loopT
+variable T equal ${Tlist}
+
+lattice         fcc ${a0}
+region          box block 0 ${nx} 0 ${nx} 0 ${nx}
+create_box      1 box
+create_atoms    1 box
+pair_style      eam
+pair_coeff      * * Al_u3.eam
+timestep        0.002
+velocity        all create ${T} 12345
+fix             1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
+
+log             log_T${T}.lammps
+run             10000
+undump          all
+clear
+next Tlist
+jump SELF loopT
+```
+
+**Execution**
+
+```bash
+lmp -in in.script_V3
+```
+
+> **Pro‑tip:** use `clear` before `next` to avoid “system already exists” errors in loops.
+
+---
+
+# Section 2.4 – Self‑describing Filenames
+
+## Slide — String variables (`in.script_V4`)
+
+```lammps
+variable  Tlist index 300 400 500
+variable  nx    equal 6
+variable  a0    equal 4.05
+
+label loopT
+variable T equal ${Tlist}
+
+log    logs/log_T${T}.lammps
+variable dumpfile string dumps/dump_T${T}_N${nx}.lammpstrj
+dump   1 all custom 200 ${dumpfile} id type x y z
+
+# ... simulation setup ...
+run 10000
+undump 1
+clear
+next Tlist
+jump SELF loopT
+```
+
+File names now carry temperature and cell size (`dump_T300_N6.lammpstrj`).
+
+---
+
+# Section 2.5 – Complete Sweep & CSV Output
+
+## Slide — Final script (`in.script_final`)
+
+Key additions: loop over cell sizes and write lattice parameter to CSV.
+
+```lammps
+variable Tlist index 300 400 500
+variable nlist index 4 6 8
+variable a0 equal 4.05
+
+label loopN
+variable nx equal ${nlist}
+
+label loopT
+variable T equal ${Tlist}
+
+# build cell
+lattice fcc ${a0}
+region box block 0 ${nx} 0 ${nx} 0 ${nx}
+create_box 1 box
+create_atoms 1 box
+pair_style eam
+pair_coeff * * Al_u3.eam
+timestep 0.002
+velocity all create ${T} 12345
+fix 1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
+
+# lattice parameter output
+variable lat equal lx/${nx}
+fix avg all ave/time 100 1 100 v_lat file results/a_vs_T.csv mode append
+
+run 10000
+unfix avg
+undump all
+clear
+
+next Tlist
+jump SELF loopT
+
+label nextN
+next nlist
+jump SELF loopN
+```
+
+Run all sweeps:
+
+```bash
+lmp -in in.script_final
+```
+
+---
+
+# Section 2.6 – Recap & Preview
+
+- Variables and loops turn a rigid script into a reusable driver.  
+- Self‑describing filenames eliminate confusion during post‑processing.  
+- Next: defect formation energies, dislocation mobility, diffusion studies.
+
+---
+### Script V1 – Hard-wired
+```lammps
+# in.script_V1 -- Hard‑wired single‑temperature run
+# Purpose: demonstrate a minimal LAMMPS input that measures lattice parameter
+# at 300 K for a 6×6×6 FCC Al cell.  No variables, no loops.
+
+units           metal
+atom_style      atomic
+boundary        p p p
+
+# --- system definition -------------------------------------------------------
+lattice         fcc 4.05                      # a0 fixed
+region          box block 0 6 0 6 0 6
+create_box      1 box
+create_atoms    1 box
+
+# --- interactions ------------------------------------------------------------
+pair_style      eam
+pair_coeff      * * Al_jnp.eam                # <‑‑ changed to Al_jnp.eam
+
+# --- run setup ---------------------------------------------------------------
+timestep        0.002         # ps
+velocity        all create 300 12345
+fix             1 all npt temp 300 300 0.1 iso 0 0 1.0
+thermo_style    custom step temp lx
+thermo          500
+
+# --- run ---------------------------------------------------------------------
+run 10000       # 20 ps
+```
+[open original](../scripts/in.script_V1)
+
+### Script V2 – Variables …
+```lammps
+# in.script_V2 -- Introduce user variables
+# Changes from V1:
+#  1. a0, T, nx, and steps promoted to variables so they can be overridden
+#     via '-var name value' on the command line.
+#  2. Region size and thermostat now reference these variables.
+#  3. Still single run, single output; no loops yet.
+
+# --- user‑defined variables (default values) ---------------------------------
+variable  a0    equal 4.05      # Å
+variable  T     string 300       # K  (string style so cmd‑line -var overrides)
+variable  nx    string 6
+variable  steps string 10000     # timesteps
+# -----------------------------------------------------------------------------
+
+units           metal
+atom_style      atomic
+boundary        p p p
+
+lattice         fcc ${a0}
+region          box block 0 ${nx} 0 ${nx} 0 ${nx}
+create_box      1 box
+create_atoms    1 box
+
+pair_style      eam
+pair_coeff      * * Al_jnp.eam
+
+timestep        0.002
+velocity        all create ${T} 12345
+
+fix             1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
+thermo_style    custom step temp lx
+thermo          500
+run             ${steps}
+
+print "INFO: Completed simulation at T=${T} K for ${steps} steps"
+```
+[open original](../scripts/in.script_V2)
+
+### Script V3 – Loop over Temperature
+```lammps
+# in.script_V3 -- Loop over temperature list, per‑T files
+# New features versus V2:
+#  * variable Tlist index ...; loop with next/jump
+#  * self‑describing log/dump filenames containing T
+#  * clear/undump so that loop restarts clean
+#  * still single cell size
+
+variable a0     equal 4.05
+variable nx     string 6
+variable steps  string 2000
+variable Tlist  index 200 300 400 500 600
+
+label loopT
+variable T equal ${Tlist}
+
+log             logs/log_T${T}.lammps
+variable dumpfile string dumps/dump_T${T}_N${nx}.lammpstrj
+
+units           metal
+atom_style      atomic
+boundary        p p p
+lattice         fcc ${a0}
+region          box block 0 ${nx} 0 ${nx} 0 ${nx}
+create_box      1 box
+create_atoms    1 box
+pair_style      eam
+pair_coeff      * * Al_jnp.eam
+
+### for calcualting the lattice parameter
+variable lat equal lx/${nx} 
+
+timestep        0.002
+velocity        all create ${T} 12345
+fix             1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
+dump            1 all custom 200 ${dumpfile} id type x y z
+thermo_style    custom step temp lx
+thermo          500
+run             ${steps}
+
+#print "INFO: Completed simulation at T=${T} K, lattice #parameter stored in ${dumpfile}" append yes
+
+print "RESULT: T=${T} K nx=${nx} a_eq=${lat} dump=${dumpfile}" append results/results.txt  screen yes
+
+undump 1
+clear
+next Tlist
+jump SELF loopT
+```
+[open original](../scripts/in.script_V3)
+
+### Script V4 – Size & Temperature Sweep
+```lammps
+# in.script_final — size & temperature sweep, NO if-statements
+
+variable a0     equal 4.05
+variable nx     index 4 6 8                  # outer loop list
+variable steps  equal 2000
+
+# -------- outer loop over nx -----------------------------------------
+label loopNx
+
+	# define temperature list fresh for each nx
+	variable T delete
+	variable T index 300 400 500 600             # inner loop list
+
+	# -------- inner loop over T ------------------------------------------
+	label loopT
+
+		log       logs/log_T${T}_N${nx}.lammps
+		variable  dumpfile string dumps/dump_T${T}_N${nx}.lammpstrj
+
+		units     metal
+		atom_style atomic
+		boundary  p p p
+		lattice   fcc ${a0}
+		region    box block 0 ${nx} 0 ${nx} 0 ${nx}
+		create_box 1 box
+		create_atoms 1 box
+
+		pair_style eam
+		pair_coeff * * Al_jnp.eam
+
+		# minimisation
+		min_style cg
+		minimize 1e-6 1e-8 1000 10000
+
+		# NPT equilibration
+		timestep   0.002
+		velocity   all create ${T} 12345
+		fix        1 all npt temp ${T} ${T} 0.1 iso 0 0 1.0
+
+		dump       1 all custom 200 ${dumpfile} id type x y z
+		variable   lat equal lx/${nx}
+		fix        avg all ave/time 100 1 100 v_lat append results/a_vs_T.csv
+
+		thermo_style custom step temp press v_lat
+		thermo     500
+		run        ${steps}
+
+		print "RESULT: T=${T} K nx=${nx} a_eq=${lat} Ang dump=${dumpfile}" append results/results.txt screen yes
+
+		undump 1
+		unfix 1
+		unfix avg
+		clear
+
+	next T
+	jump SELF loopT            # go back unless temperature list is finished
+
+# -------- advance cell size ------------------------------------------
+next nx
+jump SELF loopNx            # go back unless nx list is finished
+```
+[open original](../scripts/in.script_V4)

--- a/slides/intro.qmd
+++ b/slides/intro.qmd
@@ -3,38 +3,33 @@ title: "Hands-on Molecular Dynamics with LAMMPS"
 subtitle: "Lecture 1 – Introduction & Workflow"
 author: "Dr. K V mani Krishna"
 format:
-  revealjs:    # live presentation
+  revealjs:
     slide-number: true
-    theme: solarized
-  beamer:      # PDF copy
+  beamer:
     includes-in-header: preamble.tex
   pptx: default
-
-
-date: "2025-07-05"
-
 ---
 
-
----
 
 ## Slide 1 — Why *Classical* Molecular Dynamics?
 
 ::: incremental
-- **Classical Molecular Dynamics (MD)** simulates how atoms or molecules move by **numerically integrating Newton’s equations of motion for every particle** in the system — positions and velocities are updated at each time–step using a chosen force-field \(U(\{\mathbf r\})\). :contentReference[oaicite:0]{index=0}  
-- The method treats particles **classically** (no explicit quantum effects) but captures temperature, pressure & collective phenomena in systems spanning *\(10^2\!-\!10^8\) atoms* and *ps → µs* time windows. :contentReference[oaicite:1]{index=1}  
+- **Classical Molecular Dynamics (MD)** simulates how atoms or molecules move by **numerically integrating Newton’s equations of motion for every particle** in the system — positions and velocities are updated at each time–step using a chosen force-field $U(\{\mathbf r\})$. :contentReference[oaicite:0]{index=0}  
+- The method treats particles **classically** (no explicit quantum effects) but captures temperature, pressure & collective phenomena in systems spanning $10^{2}$–$10^{8}$ atoms and ps → µs time windows. :contentReference[oaicite:1]{index=1}
 - **Historic origin:** *Alder & Wainwright (1957)* used hard-sphere MD to show fluid–solid phase transitions — the first computer “microscope”. :contentReference[oaicite:2]{index=2}  
 - **Today:** MD is the bridge between quantum DFT (Å & fs) and continuum FEM (mm & s), enabling predictive metallurgy, diffusion, dislocation kinetics, and nanomechanics. :contentReference[oaicite:3]{index=3}  
 :::
 
 ![Historic (1957) vs. modern GPU MD](../images/md_history_vs_today.png){#fig:history width="80%"}
 
-> **Key equation:**  
-> \[
+> **Key equation:**
+>
+> $$
 > m_i\frac{d^{2}\mathbf r_i}{dt^{2}} = -\nabla_{\!i}\,U(\{\mathbf r\}) ,
 > \quad U = \text{EAM/MEAM/… force-field}
-> \]  
-> *\(m_i\)* = atom mass, *\(\mathbf r_i\)* = position, *\(U\)* = potential energy. :contentReference[oaicite:4]{index=4}
+> $$
+>
+> $m_i$ = atom mass, $\mathbf r_i$ = position, $U$ = potential energy. :contentReference[oaicite:4]{index=4}
 
 
 ---


### PR DESCRIPTION
## Summary
- add YAML front matter to all slide `.qmd` files
- sync `day1_intro`, `day-2-demos`, and `intro` content with respective markdown
- fix math delimiters to avoid LaTeX errors

## Testing
- `quarto render slides/intro.qmd`
- `quarto render slides/day1_intro.qmd`
- `quarto render slides/day-2-demos.qmd`


------
https://chatgpt.com/codex/tasks/task_e_6867674ba248832491e420ecf8c3ca80